### PR TITLE
Updated to include statefulset

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -23,15 +23,17 @@ first create a namespace called filebin2
 
 Then edit the deployment and service files with your details and deploy them. The service file also shows the annotations needed for an SSL load balancer using AWS, for this create an SSL certificate first.
 
-Then deploy.
+First a service (Very important this is done first if you are using a StatefulSet)
+**kubectl -n filebin2 apply -f  service/filebin2-service.yaml**
 
+As a deployment
 **kubectl -n filebin2 apply -f  deployments/filebin2-deployment.yaml**
 
-and
+Or as a StatefulSet (if you need more /tmp space than the k8s node provide ) -Prefered approach
 
-**kubectl -n filebin2 apply -f  service/filebin2-service.yaml**
+**kubectl -n filebin2 apply -f  statefulsets/filebin2-statefulset.yaml**
+
 
 At this point you should have a working version of filebin2 running on k8s congrats!
 
 
-> Written with [StackEdit](https://stackedit.io/).

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,39 +1,54 @@
-**Filebin2 deploying to Kubernetes**
+# Filebin2 deploying to Kubernetes
 
 ## Building the filebin2 binary and creating a docker image.
 
-The filebin2 binary is best created by a CI/CD pipeline the binary should be built with static links using the following command.
+The filebin2 binary is best created by a CI/CD pipeline the binary should be
+built with static links using the following command.
 
+```bash
 go build -tags netgo -ldflags '-extldflags "-static"'
+```
 
-The binary can then be copied to the docker subdirectory and the docker container can be built using the Dockerfile in the docker sub directory. The resulting docker image needs to be pushed to dockerhub.
+The binary can then be copied to the docker subdirectory and the docker
+container can be built using the Dockerfile in the docker sub directory.
+The resulting docker image needs to be pushed to dockerhub.
 
 ## Build your database
-Filebin2 requires a Postgres database to store state for all the K8S deployments of the binary. Build a Postgres database and set it up using the SQL commands in  the schema.sql file.
- Ensure you know the database DNS port number and the username and password for the database as you will need that to configure the k8s deployments.
+Filebin2 requires a Postgres database to store state for all the K8S
+deployments of the binary. Build a Postgres database and set it up using
+the SQL commands in the schema.sql file.  
+
+Ensure you know the database DNS port number and the username and password
+for the database as you will need that to configure the k8s deployments.
 
 
 ## Deploying to Kubernetes
 
-Only two yaml files are required for deployment to k8s one is a deployment and the second a service. To install them you need access to a k8s cluster and the kubectl command.
+Only two yaml files are required for deployment to k8s one is a deployment
+and the second a service. To install them you need access to a k8s cluster
+and the kubectl command.
 
 first create a namespace called filebin2
 
-**kubectl create namespace filebin2**
+```bash
+kubectl create namespace filebin2
+```
 
-Then edit the deployment and service files with your details and deploy them. The service file also shows the annotations needed for an SSL load balancer using AWS, for this create an SSL certificate first.
+Then edit the deployment and service files with your details and deploy them.
+The service file also shows the annotations needed for an SSL load balancer
+using AWS, for this create an SSL certificate first.
 
-First a service (Very important this is done first if you are using a StatefulSet)
-**kubectl -n filebin2 apply -f  service/filebin2-service.yaml**
+Then deploy:
 
-As a deployment
-**kubectl -n filebin2 apply -f  deployments/filebin2-deployment.yaml**
+```bash
+kubectl -n filebin2 apply -f  deployments/filebin2-deployment.yaml
+```
 
-Or as a StatefulSet (if you need more /tmp space than the k8s node provide ) -Prefered approach
+and
 
-**kubectl -n filebin2 apply -f  statefulsets/filebin2-statefulset.yaml**
+```bash
+kubectl -n filebin2 apply -f  service/filebin2-service.yaml
+```
 
-
-At this point you should have a working version of filebin2 running on k8s congrats!
-
-
+At this point you should have a working version of filebin2 running on k8s
+congrats!

--- a/k8s/statefulsets/filebin2-statefulset.yaml
+++ b/k8s/statefulsets/filebin2-statefulset.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: filebin2-statefulset
+spec:
+  selector:
+    matchLabels:
+      app: filebin2-statefulset
+  serviceName: "filebin2-service"
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: filebin2-statefulset
+    spec:
+      containers:
+      - args:
+          - '-db-host'
+          - <database hostname>
+          - '-db-name'
+          - <database name>
+          - '-db-password'
+          - <database password>
+          - '-db-port'
+          - <database port number>
+          - '-db-username'
+          - <database username>
+          - '-listen-host'
+          - 0.0.0.0
+          - '--baseurl'
+          - <baseurl>
+        env:
+          - name: S3_ENDPOINT
+            value: <DNS location of bucket>
+          - name: S3_REGION
+            value: <s3 region>
+          - name: S3_BUCKET
+            value: <bucket name>
+          - name: S3_ACCESS_KEY
+            value: <s3 access key>
+          - name: S3_SECRET_KEY
+            value: <s3 secret key>
+          - name: S3_ENCRYPTION_KEY
+            value: <s3 encryption key>
+          - name: ADMIN_USERNAME
+            value: <admin username>
+          - name: ADMIN_PASSWORD
+            value: <admin password>
+        envFrom:
+        - secretRef:
+            name: fb2usecrets
+        image: <xxxxxxxx/filebin2 or your docker image>
+        imagePullPolicy: Always
+        name: filebin2upstream
+        resources:
+          limits:
+            cpu: 250m
+            ephemeral-storage: 2Gi
+            memory: 4Gi
+          requests:
+            cpu: 250m
+            ephemeral-storage: 2Gi
+            memory: 4Gi
+        volumeMounts:
+        - name: filebin2-pvc
+          mountPath: /tmp
+      securityContext:
+        fsGroup: <Group of defgault user so filebin2 can write to /tmp>
+        seccompProfile:
+          type: RuntimeDefault
+  volumeClaimTemplates:
+  - metadata:
+      name: filebin2-pvc
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 100Gi
+      storageClassName: standard


### PR DESCRIPTION
<!--
Added default config for a statefulset configuration (which mirrors what was done with our install on GKE)


-->

**- What I did**

Updated readme and created a default template for a statefulset. This allows each pod a stateful /tmp directory which can be as large as required. 
The original deployment /tmp can only be as large as the nodes / drive (On GKE as default that is 10GB)

**- How I did it**
Edited files
**- How to verify it**
Its working in production
**- Description for the changelog**
<!--
Created statefulset default files for anyone wanting to install Filebin2 on K8S using a StatefulSet
-->